### PR TITLE
Updated error in except block for removal of id attribute

### DIFF
--- a/Basics/Exercise/16_class_and_objects/16_class_and_objects.py
+++ b/Basics/Exercise/16_class_and_objects/16_class_and_objects.py
@@ -17,7 +17,7 @@ del emp.id
 # Deleting the object itself
 try:
     print(emp.id)
-except NameError:
+except AttributeError:
     print("emp.id is not defined")
 
 del emp


### PR DESCRIPTION
The error in  except block to catch the exception thrown after removal of id attribute should be AttributeError and not NameError as observed in python 3.13.1