### PR TITLE
Fix deprecated base_estimator in BaggingClassifier (Issue #284)

### DIFF
--- a/ML/19_Bagging/bagging_diabetes_prediction.ipynb
+++ b/ML/19_Bagging/bagging_diabetes_prediction.ipynb
@@ -620,7 +620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -638,7 +638,7 @@
     "from sklearn.ensemble import BaggingClassifier\n",
     "\n",
     "bag_model = BaggingClassifier(\n",
-    "    base_estimator=DecisionTreeClassifier(), \n",
+    "    estimator=DecisionTreeClassifier(), \n",
     "    n_estimators=100, \n",
     "    max_samples=0.8, \n",
     "    oob_score=True,\n",
@@ -670,7 +670,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -686,7 +686,7 @@
    ],
    "source": [
     "bag_model = BaggingClassifier(\n",
-    "    base_estimator=DecisionTreeClassifier(), \n",
+    "    estimator=DecisionTreeClassifier(), \n",
     "    n_estimators=100, \n",
     "    max_samples=0.8, \n",
     "    oob_score=True,\n",


### PR DESCRIPTION
This PR fixes the deprecation warning for base_estimator in BaggingClassifier by replacing it with estimator. This resolves Issue #284.